### PR TITLE
Fix: do not run product info parsing logic on non product pages

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -26,17 +26,18 @@ sendMessageToBackground().then(() => {
 async function liveTimeBaby() {
   console.group("Porovnání cen by TopMonks");
 
-  const {
-    isProductPage,
-    productName,
-    productPrice,
-    createRootElement
-  } = scrawler(location);
+  const parsed = scrawler(location);
 
-  if (!isProductPage) {
+  if (!parsed.isProductPage) {
     console.log("Not a product page.");
     return;
   }
+
+  const {
+    productName,
+    productPrice,
+    createRootElement
+  } = parsed;
 
   if (!productName) {
     console.log("Product name not found.", productName);


### PR DESCRIPTION
Due to current architecture based on object getters and destructuring, product page logic is executed also on non-product pages... e.g. `productPrice` is called on e-shop home page.

Current 🤔

![2020-03-24 07 50 01](https://user-images.githubusercontent.com/697301/77397344-b2803700-6da5-11ea-9481-0340fdceb4d2.gif)

Proposed 🥳

![2020-03-24 07 55 23](https://user-images.githubusercontent.com/697301/77397440-e6f3f300-6da5-11ea-9657-e70dd1441d00.gif)

---

I'm working on more support for more shops, and in some, the logic for getting the price is a little bit more complicated and it should be run only if needed.
