### PR TITLE
Optimize build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-rm -f build.zip || true
-zip -r build.zip build

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "webpack --mode=production",
+    "build-and-zip": "rm -rf build build.zip && npm run build && cd build && zip -r ../build.zip ./ && echo '\n=== build.zip prepared ===\n'",
     "develop": "webpack --mode=development --watch",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",


### PR DESCRIPTION
🚨 Pozor, breaking change, ale IMO spravna 🚨

Chrome Web Store zip prelouska i kdyz je extension samotna zanorena v directory (v nasem pripade `build`) ale Firefox Add-ony vyzaduji aby vse bylo v rootu zipu.

![image](https://user-images.githubusercontent.com/697301/82473942-97daed80-9aca-11ea-9f1b-9d964ce8148f.png)
